### PR TITLE
Update start-minecraft.sh

### DIFF
--- a/minecraft-server/start-minecraft.sh
+++ b/minecraft-server/start-minecraft.sh
@@ -216,10 +216,10 @@ case "X$MODPACK" in
     wget -q -O /tmp/modpack.zip "$MODPACK"
     if [ "$TYPE" = "SPIGOT" ]; then
       mkdir -p /data/plugins
-      unzip -d /data/plugins /tmp/modpack.zip
+      unzip -o -d /data/plugins /tmp/modpack.zip
     else
       mkdir -p /data/mods
-      unzip -d /data/mods /tmp/modpack.zip
+      unzip -o -d /data/mods /tmp/modpack.zip
     fi
     rm -f /tmp/modpack.zip
     ;;


### PR DESCRIPTION
Each time this script is run it downloads the modpack if one is specified. When it tries to unzip the file, if the files already exist in the plugins directory, the script will hang indefinitely because unzip asks for confirmation that you want to overwrite the existing files. Adding -o to the unzip command will tell it to overwrite the files. I suspect the world download has the same issue, but I don't use that and so can't really test it.